### PR TITLE
Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM opensuse/tumbleweed:latest
+MAINTAINER Volker Theile <vtheile@suse.com>
+
+RUN zypper ref && \
+    zypper --non-interactive install prometheus-webhook-snmp && \
+    zypper clean -a
+
+ENV ARGS=""
+
+CMD exec /usr/bin/prometheus-webhook-snmp --debug run $ARGS

--- a/prometheus-webhook-snmp.conf
+++ b/prometheus-webhook-snmp.conf
@@ -1,0 +1,2 @@
+port: 9099
+metrics: True


### PR DESCRIPTION
Build image from Dockerfile:
```
$ docker build -t prometheus-webhook-snmp .
$ docker run -v $(pwd)/prometheus-webhook-snmp.conf:/etc/prometheus-webhook-snmp.conf -p 9099:9099 prometheus-webhook-snmp:latest
```

Fixes: https://github.com/SUSE/prometheus-webhook-snmp/issues/24

Signed-off-by: Volker Theile <vtheile@suse.com>