### PR TITLE
Add a feature that enables https 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To start the receiver execute the command:
 
     $ ./prometheus-webhook-snmp run
 
+To start with HTTPS, pass the certificate and key parameters:
+
+    $ ./prometheus-webhook-snmp --cert "certificate.pem" --key "key.pem" run
+
+Note: Both '--cert' and '--key' are needed to enable HTTPS.
 # Send a test SNMP trap
 
 If you want to send a test SNMP trap, then simply execute the following command. This can be used to test your command line parameters.

--- a/prometheus-webhook-snmp
+++ b/prometheus-webhook-snmp
@@ -72,11 +72,18 @@ def cli(ctx, debug, snmp_host, snmp_port, snmp_community, snmp_retries,
 @click.option('--metrics',
               is_flag=True,
               help='Provide Prometheus metrics from this receiver.')
+@click.option('--cert',
+              help='The CA certificate for setting up HTTPS. '
+                   'Need to be used with --key. Without this option, HTTP is used.')
+@click.option('--key',
+              help='The CA private key for setting up HTTPS. Need to be used with --cert.')
 @pass_context
-def run(ctx, host, port, metrics):
+def run(ctx, host, port, metrics, cert, key):
     ctx.config['host'] = host
     ctx.config['port'] = port
     ctx.config['metrics'] = True if metrics else None
+    ctx.config['cert'] = cert
+    ctx.config['key'] = key
     ctx.config.dump()
     utils.run_http_server(ctx)
     sys.exit(0)

--- a/prometheus_webhook_snmp/utils.py
+++ b/prometheus_webhook_snmp/utils.py
@@ -184,6 +184,15 @@ def run_http_server(ctx):
     :param ctx: The application context.
     :type ctx: dict
     """
+    if ctx.config['cert'] and ctx.config['key']:
+        cherrypy.config.update({
+            'server.ssl_module': 'builtin',
+            'server.ssl_certificate': ctx.config['cert'],
+            'server.ssl_private_key': ctx.config['key']
+        })
+    elif ctx.config['cert'] or ctx.config['key']:
+        raise Exception("Both '--cert' and '--key' are needed")
+
     cherrypy.config.update({
         'environment': 'production',
         'server.socket_host': ctx.config['host'],
@@ -217,7 +226,9 @@ class Config(dict):
             'trap_default_severity': '',
             'host': '0.0.0.0',
             'port': 9099,
-            'metrics': False
+            'metrics': False,
+            'cert': '',
+            'key': ''
         }
 
     def dump(self):


### PR DESCRIPTION
This PR adds a new feature that allows user to enable TLS on the http server that receives alerts from the prometheus alert manager. 